### PR TITLE
Resubmitted: Fixed issue when SunSet/Sunrise is on a different day from variable date

### DIFF
--- a/Solar/Solar.swift
+++ b/Solar/Solar.swift
@@ -218,23 +218,11 @@ extension Solar {
         let todaySunset = sunset.timeIntervalSince1970
         let currentTime = self.date.timeIntervalSince1970
         
-        var yesterday = Date()
-        if #available(iOSApplicationExtension 13.0, *) {
-            yesterday = date.advanced(by: TimeInterval(exactly: -86400.0)!)
-        } else {
-            
-            yesterday = date.addingTimeInterval(TimeInterval(exactly: -86400.0)!)
-        }
+        let yesterday  = date.addingTimeInterval(TimeInterval(exactly: -86400.0)!)
         let yesterdaySunrise = calculate(.sunrise, for: yesterday, and: .official)?.timeIntervalSince1970
         let yesterdaySunset = calculate(.sunset, for: yesterday, and: .official)?.timeIntervalSince1970
         
-        var tomorrow = Date()
-        if #available(iOSApplicationExtension 13.0, *) {
-            tomorrow = date.advanced(by: TimeInterval(exactly: 86400.0)!)
-        } else {
-            tomorrow = date.addingTimeInterval(TimeInterval(exactly: 86400.0)!)
-        }
-        
+        let tomorrow = date.addingTimeInterval(TimeInterval(exactly: 86400.0)!)
         let tomorrowSunrise = calculate(.sunrise, for: tomorrow, and: .official)?.timeIntervalSince1970
         let tomorrowSunSet = calculate(.sunset, for: tomorrow, and: .official)?.timeIntervalSince1970
         

--- a/Solar/Solar.swift
+++ b/Solar/Solar.swift
@@ -214,14 +214,35 @@ extension Solar {
                 return false
         }
         
-        let beginningOfDay = sunrise.timeIntervalSince1970
-        let endOfDay = sunset.timeIntervalSince1970
+        let todaySunrise = sunrise.timeIntervalSince1970
+        let todaySunset = sunset.timeIntervalSince1970
         let currentTime = self.date.timeIntervalSince1970
         
-        let isSunriseOrLater = currentTime >= beginningOfDay
-        let isBeforeSunset = currentTime < endOfDay
+        var yesterday = Date()
+        if #available(iOSApplicationExtension 13.0, *) {
+            yesterday = date.advanced(by: TimeInterval(exactly: -86400.0)!)
+        } else {
+            
+            yesterday = date.addingTimeInterval(TimeInterval(exactly: -86400.0)!)
+        }
+        let yesterdaySunrise = calculate(.sunrise, for: yesterday, and: .official)?.timeIntervalSince1970
+        let yesterdaySunset = calculate(.sunset, for: yesterday, and: .official)?.timeIntervalSince1970
         
-        return isSunriseOrLater && isBeforeSunset
+        var tomorrow = Date()
+        if #available(iOSApplicationExtension 13.0, *) {
+            tomorrow = date.advanced(by: TimeInterval(exactly: 86400.0)!)
+        } else {
+            tomorrow = date.addingTimeInterval(TimeInterval(exactly: 86400.0)!)
+        }
+        
+        let tomorrowSunrise = calculate(.sunrise, for: tomorrow, and: .official)?.timeIntervalSince1970
+        let tomorrowSunSet = calculate(.sunset, for: tomorrow, and: .official)?.timeIntervalSince1970
+        
+        let isDayYesterday = yesterdaySunrise! < currentTime && currentTime < yesterdaySunset!
+        let isDayToday = todaySunrise < currentTime && currentTime < todaySunset
+        let isDayTomorrow = tomorrowSunrise! < currentTime && currentTime < tomorrowSunSet!
+        
+        return isDayYesterday || isDayToday || isDayTomorrow
     }
     
     /// Whether the location specified by the `latitude` and `longitude` is in nighttime on `date`


### PR DESCRIPTION
Resubmitted from #44 

Fixed the following scenario.

When Sunrise timing is 2300 while current time is 2330, isDayTime wrongly shows false.
When sunset timing is 0050 while current time is 0030, isDayTime wrongly shows false.