### PR TITLE
Update iOS deployment target from `8.0` to `9.0`.

### DIFF
--- a/Solar.podspec
+++ b/Solar.podspec
@@ -6,7 +6,7 @@ Pod::Spec.new do |s|
   s.homepage     = "http://github.com/ceek/solar"
   s.license      = { :type => "MIT", :file => "LICENSE" }
   s.author             = { "Chris Howell" => "chris.kevin.howell@gmail.com" }
-  s.ios.deployment_target = '8.0'
+  s.ios.deployment_target = '9.0'
   s.watchos.deployment_target = '3.0'
   s.tvos.deployment_target = '9.0'
   s.osx.deployment_target = '10.9'

--- a/Solar.xcodeproj/project.pbxproj
+++ b/Solar.xcodeproj/project.pbxproj
@@ -347,7 +347,7 @@
 			isa = PBXProject;
 			attributes = {
 				LastSwiftUpdateCheck = 1240;
-				LastUpgradeCheck = 1240;
+				LastUpgradeCheck = 1250;
 				ORGANIZATIONNAME = "Chris Howell";
 				TargetAttributes = {
 					1410E9BF1EF12B5A001829A5 = {
@@ -387,6 +387,7 @@
 			hasScannedForEncodings = 0;
 			knownRegions = (
 				en,
+				Base,
 			);
 			mainGroup = F7FC5B501D469B2700C4D3EB;
 			productRefGroup = F7FC5B5B1D469B2700C4D3EB /* Products */;
@@ -886,7 +887,7 @@
 				GCC_WARN_UNINITIALIZED_AUTOS = YES_AGGRESSIVE;
 				GCC_WARN_UNUSED_FUNCTION = YES;
 				GCC_WARN_UNUSED_VARIABLE = YES;
-				IPHONEOS_DEPLOYMENT_TARGET = 8.0;
+				IPHONEOS_DEPLOYMENT_TARGET = 9.0;
 				MACOSX_DEPLOYMENT_TARGET = 10.9;
 				MTL_ENABLE_DEBUG_INFO = YES;
 				ONLY_ACTIVE_ARCH = YES;
@@ -945,7 +946,7 @@
 				GCC_WARN_UNINITIALIZED_AUTOS = YES_AGGRESSIVE;
 				GCC_WARN_UNUSED_FUNCTION = YES;
 				GCC_WARN_UNUSED_VARIABLE = YES;
-				IPHONEOS_DEPLOYMENT_TARGET = 8.0;
+				IPHONEOS_DEPLOYMENT_TARGET = 9.0;
 				MACOSX_DEPLOYMENT_TARGET = 10.9;
 				MTL_ENABLE_DEBUG_INFO = NO;
 				SDKROOT = iphoneos;

--- a/Solar.xcodeproj/xcshareddata/xcschemes/Solar iOS.xcscheme
+++ b/Solar.xcodeproj/xcshareddata/xcschemes/Solar iOS.xcscheme
@@ -1,6 +1,6 @@
 <?xml version="1.0" encoding="UTF-8"?>
 <Scheme
-   LastUpgradeVersion = "1240"
+   LastUpgradeVersion = "1250"
    version = "1.3">
    <BuildAction
       parallelizeBuildables = "YES"

--- a/Solar.xcodeproj/xcshareddata/xcschemes/Solar macOS.xcscheme
+++ b/Solar.xcodeproj/xcshareddata/xcschemes/Solar macOS.xcscheme
@@ -1,6 +1,6 @@
 <?xml version="1.0" encoding="UTF-8"?>
 <Scheme
-   LastUpgradeVersion = "1240"
+   LastUpgradeVersion = "1250"
    version = "1.3">
    <BuildAction
       parallelizeBuildables = "YES"

--- a/Solar.xcodeproj/xcshareddata/xcschemes/Solar tvOS.xcscheme
+++ b/Solar.xcodeproj/xcshareddata/xcschemes/Solar tvOS.xcscheme
@@ -1,6 +1,6 @@
 <?xml version="1.0" encoding="UTF-8"?>
 <Scheme
-   LastUpgradeVersion = "1240"
+   LastUpgradeVersion = "1250"
    version = "1.3">
    <BuildAction
       parallelizeBuildables = "YES"

--- a/Solar.xcodeproj/xcshareddata/xcschemes/Solar watchOS.xcscheme
+++ b/Solar.xcodeproj/xcshareddata/xcschemes/Solar watchOS.xcscheme
@@ -1,6 +1,6 @@
 <?xml version="1.0" encoding="UTF-8"?>
 <Scheme
-   LastUpgradeVersion = "1240"
+   LastUpgradeVersion = "1250"
    version = "1.3">
    <BuildAction
       parallelizeBuildables = "YES"


### PR DESCRIPTION
Update iOS deployment target from `8.0` to `9.0` to compilation warnings while building https://github.com/mapbox/mapbox-navigation-ios.